### PR TITLE
Replaced `jQuery(document).ready(function(){` with `jQuery(function(){`

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,5 +1,5 @@
 
-jQuery(document).ready(function($) {
+jQuery(function($) {
     $('.js-bpml-register-fields').click(function() {
         var button = $(this);
         button.off().after('<div class="spinner"></div>').next().show();


### PR DESCRIPTION
Handled also deprecated variations described in
https://api.jquery.com/ready/

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlga-786